### PR TITLE
Add monitoring summary endpoint with caching

### DIFF
--- a/proxy/main.go
+++ b/proxy/main.go
@@ -1,23 +1,380 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/rs/cors"
 )
 
 var (
-	connectURL       = getEnv("KAFKA_CONNECT_URL", "http://localhost:8083")
-	allowedOrigins   = getEnv("ALLOWED_ORIGINS", "*")
-	sensitivePattern = regexp.MustCompile(`(?i)(password|secret|token|key|credential|auth)`)
+	connectURL             = getEnv("KAFKA_CONNECT_URL", "http://localhost:8083")
+	allowedOrigins         = getEnv("ALLOWED_ORIGINS", "*")
+	sensitivePattern       = regexp.MustCompile(`(?i)(password|secret|token|key|credential|auth)`)
+	monitoringHTTPClient   = &http.Client{}
+	summaryCacheTTL        = 10 * time.Second
+	monitoringSummaryCache = struct {
+		sync.Mutex
+		data      MonitoringSummary
+		expiresAt time.Time
+		valid     bool
+	}{}
 )
+
+// MonitoringSummary represents aggregated status information for connectors.
+type MonitoringSummary struct {
+	TotalConnectors int                       `json:"totalConnectors"`
+	ConnectorStates map[string]int            `json:"connectorStates"`
+	TaskStates      map[string]int            `json:"taskStates"`
+	UptimeSeconds   int64                     `json:"uptimeSeconds"`
+	Connectors      []ConnectorStatusOverview `json:"connectors"`
+}
+
+// ConnectorStatusOverview provides a condensed view of an individual connector.
+type ConnectorStatusOverview struct {
+	Name  string `json:"name"`
+	State string `json:"state"`
+	Type  string `json:"type"`
+}
+
+type connectorStatusResponse struct {
+	Name      string `json:"name"`
+	Connector struct {
+		State    string `json:"state"`
+		WorkerID string `json:"worker_id"`
+	} `json:"connector"`
+	Tasks []struct {
+		ID       int    `json:"id"`
+		State    string `json:"state"`
+		WorkerID string `json:"worker_id"`
+	} `json:"tasks"`
+	Type string `json:"type"`
+}
+
+type connectUnavailableError struct {
+	err error
+}
+
+func (e *connectUnavailableError) Error() string {
+	return fmt.Sprintf("kafka connect is unreachable: %v", e.err)
+}
+
+func (e *connectUnavailableError) Unwrap() error {
+	return e.err
+}
+
+func newStateCounter() map[string]int {
+	return map[string]int{
+		"running":    0,
+		"paused":     0,
+		"failed":     0,
+		"unassigned": 0,
+		"unknown":    0,
+	}
+}
+
+func normalizeState(state string) string {
+	switch strings.ToUpper(state) {
+	case "RUNNING":
+		return "running"
+	case "PAUSED":
+		return "paused"
+	case "FAILED":
+		return "failed"
+	case "UNASSIGNED":
+		return "unassigned"
+	default:
+		return "unknown"
+	}
+}
+
+func joinURL(base string, parts ...string) string {
+	trimmed := strings.TrimSuffix(base, "/")
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		trimmed += "/" + strings.TrimPrefix(part, "/")
+	}
+	return trimmed
+}
+
+func fetchConnectorNames(ctx context.Context, client *http.Client, baseURL string) ([]string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, joinURL(baseURL, "connectors"), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, &connectUnavailableError{err: err}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status fetching connectors: %d", resp.StatusCode)
+	}
+
+	var names []string
+	if err := json.NewDecoder(resp.Body).Decode(&names); err != nil {
+		return nil, fmt.Errorf("decode connectors: %w", err)
+	}
+
+	return names, nil
+}
+
+func fetchConnectorStatus(ctx context.Context, client *http.Client, baseURL, name string) (connectorStatusResponse, error) {
+	escaped := url.PathEscape(name)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, joinURL(baseURL, "connectors", escaped, "status"), nil)
+	if err != nil {
+		return connectorStatusResponse{}, err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return connectorStatusResponse{}, &connectUnavailableError{err: err}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return connectorStatusResponse{}, fmt.Errorf("unexpected status fetching connector %s: %d", name, resp.StatusCode)
+	}
+
+	var status connectorStatusResponse
+	if err := json.NewDecoder(resp.Body).Decode(&status); err != nil {
+		return connectorStatusResponse{}, fmt.Errorf("decode connector status for %s: %w", name, err)
+	}
+
+	return status, nil
+}
+
+func fetchClusterUptime(ctx context.Context, client *http.Client, baseURL string) (time.Duration, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimSuffix(baseURL, "/"), nil)
+	if err != nil {
+		return 0, err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, &connectUnavailableError{err: err}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("unexpected status fetching connect metadata: %d", resp.StatusCode)
+	}
+
+	var payload map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return 0, fmt.Errorf("decode connect metadata: %w", err)
+	}
+
+	if uptime, ok := extractUptimeSeconds(payload); ok {
+		return time.Duration(uptime) * time.Second, nil
+	}
+
+	return 0, nil
+}
+
+func extractUptimeSeconds(data map[string]interface{}) (int64, bool) {
+	for key, value := range data {
+		switch v := value.(type) {
+		case map[string]interface{}:
+			if uptime, ok := extractUptimeSeconds(v); ok {
+				return uptime, true
+			}
+		case []interface{}:
+			for _, item := range v {
+				if nested, ok := item.(map[string]interface{}); ok {
+					if uptime, ok := extractUptimeSeconds(nested); ok {
+						return uptime, true
+					}
+				}
+			}
+		default:
+			if strings.EqualFold(key, "uptime_ms") {
+				ms, err := parseMilliseconds(v)
+				if err == nil {
+					return ms / 1000, true
+				}
+			}
+			if strings.EqualFold(key, "uptime") {
+				seconds, err := parseSeconds(v)
+				if err == nil {
+					return seconds, true
+				}
+			}
+		}
+	}
+	return 0, false
+}
+
+func parseMilliseconds(value interface{}) (int64, error) {
+	switch v := value.(type) {
+	case float64:
+		return int64(v), nil
+	case int64:
+		return v, nil
+	case json.Number:
+		i, err := v.Int64()
+		if err != nil {
+			return 0, err
+		}
+		return i, nil
+	case string:
+		s := strings.TrimSpace(v)
+		lower := strings.ToLower(s)
+		switch {
+		case strings.HasSuffix(lower, "ms"):
+			return parseInt(strings.TrimSpace(s[:len(s)-2]))
+		case strings.HasSuffix(lower, "s"):
+			seconds, err := parseInt(strings.TrimSpace(s[:len(s)-1]))
+			if err != nil {
+				return 0, err
+			}
+			return seconds * 1000, nil
+		default:
+			return parseInt(s)
+		}
+	default:
+		return 0, fmt.Errorf("unsupported numeric type %T", value)
+	}
+}
+
+func parseSeconds(value interface{}) (int64, error) {
+	switch v := value.(type) {
+	case float64:
+		return int64(v), nil
+	case int64:
+		return v, nil
+	case json.Number:
+		i, err := v.Int64()
+		if err != nil {
+			return 0, err
+		}
+		return i, nil
+	case string:
+		s := strings.TrimSpace(v)
+		lower := strings.ToLower(s)
+		switch {
+		case strings.HasSuffix(lower, "ms"):
+			ms, err := parseInt(strings.TrimSpace(s[:len(s)-2]))
+			if err != nil {
+				return 0, err
+			}
+			return ms / 1000, nil
+		case strings.HasSuffix(lower, "s"):
+			return parseInt(strings.TrimSpace(s[:len(s)-1]))
+		default:
+			return parseInt(s)
+		}
+	default:
+		return 0, fmt.Errorf("unsupported numeric type %T", value)
+	}
+}
+
+func parseInt(value string) (int64, error) {
+	if value == "" {
+		return 0, fmt.Errorf("empty numeric value")
+	}
+	return strconv.ParseInt(value, 10, 64)
+}
+
+func fetchMonitoringSummary(ctx context.Context, client *http.Client, baseURL string) (MonitoringSummary, error) {
+	names, err := fetchConnectorNames(ctx, client, baseURL)
+	if err != nil {
+		return MonitoringSummary{}, err
+	}
+
+	connectorStates := newStateCounter()
+	taskStates := newStateCounter()
+	overviews := make([]ConnectorStatusOverview, 0, len(names))
+
+	for _, name := range names {
+		status, err := fetchConnectorStatus(ctx, client, baseURL, name)
+		if err != nil {
+			return MonitoringSummary{}, err
+		}
+
+		state := normalizeState(status.Connector.State)
+		connectorStates[state]++
+		overviews = append(overviews, ConnectorStatusOverview{
+			Name:  status.Name,
+			State: state,
+			Type:  status.Type,
+		})
+
+		for _, task := range status.Tasks {
+			taskState := normalizeState(task.State)
+			taskStates[taskState]++
+		}
+	}
+
+	uptime, err := fetchClusterUptime(ctx, client, baseURL)
+	if err != nil {
+		var cue *connectUnavailableError
+		if errors.As(err, &cue) {
+			return MonitoringSummary{}, err
+		}
+		log.Printf("warning: failed to fetch connect uptime: %v", err)
+	}
+
+	summary := MonitoringSummary{
+		TotalConnectors: len(names),
+		ConnectorStates: connectorStates,
+		TaskStates:      taskStates,
+		UptimeSeconds:   int64(uptime.Seconds()),
+		Connectors:      overviews,
+	}
+
+	return summary, nil
+}
+
+func getMonitoringSummary(ctx context.Context) (MonitoringSummary, error) {
+	now := time.Now()
+
+	monitoringSummaryCache.Lock()
+	if monitoringSummaryCache.valid && now.Before(monitoringSummaryCache.expiresAt) {
+		summary := monitoringSummaryCache.data
+		monitoringSummaryCache.Unlock()
+		return summary, nil
+	}
+	monitoringSummaryCache.Unlock()
+
+	summary, err := fetchMonitoringSummary(ctx, monitoringHTTPClient, connectURL)
+	if err != nil {
+		return MonitoringSummary{}, err
+	}
+
+	monitoringSummaryCache.Lock()
+	monitoringSummaryCache.data = summary
+	monitoringSummaryCache.expiresAt = time.Now().Add(summaryCacheTTL)
+	monitoringSummaryCache.valid = true
+	monitoringSummaryCache.Unlock()
+
+	return summary, nil
+}
+
+func resetMonitoringSummaryCache() {
+	monitoringSummaryCache.Lock()
+	monitoringSummaryCache.data = MonitoringSummary{}
+	monitoringSummaryCache.expiresAt = time.Time{}
+	monitoringSummaryCache.valid = false
+	monitoringSummaryCache.Unlock()
+}
 
 func getEnv(key, defaultValue string) string {
 	if value := os.Getenv(key); value != "" {
@@ -63,7 +420,7 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 	} else {
 		targetURL = fmt.Sprintf("%s/%s", connectURL, path)
 	}
-	
+
 	log.Printf("Proxying %s %s to %s", r.Method, r.URL.Path, targetURL)
 
 	// Create the proxy request
@@ -133,6 +490,39 @@ func healthHandler(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+func monitoringSummaryHandler(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	_ = vars["cluster"]
+
+	summary, err := getMonitoringSummary(r.Context())
+	if err != nil {
+		status := http.StatusBadGateway
+		payload := map[string]string{
+			"error":   "summary_fetch_failed",
+			"message": err.Error(),
+		}
+
+		var cue *connectUnavailableError
+		if errors.As(err, &cue) {
+			status = http.StatusServiceUnavailable
+			payload["error"] = "connect_unreachable"
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		if err := json.NewEncoder(w).Encode(payload); err != nil {
+			log.Printf("failed to encode error response: %v", err)
+		}
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(summary); err != nil {
+		log.Printf("failed to encode summary response: %v", err)
+	}
+}
+
 func main() {
 	router := mux.NewRouter()
 
@@ -143,6 +533,7 @@ func main() {
 	router.HandleFunc("/api/{cluster}/connectors", proxyHandler).Methods("GET", "POST")
 	router.HandleFunc("/api/{cluster}/connectors/", proxyHandler).Methods("GET", "POST")
 	router.HandleFunc("/api/{cluster}/connectors/{path:.*}", proxyHandler).Methods("GET", "POST", "PUT", "DELETE")
+	router.HandleFunc("/api/{cluster}/monitoring/summary", monitoringSummaryHandler).Methods("GET")
 
 	// CORS configuration
 	// In production, set ALLOWED_ORIGINS environment variable to specific domains
@@ -151,7 +542,7 @@ func main() {
 	if allowedOrigins != "*" {
 		origins = []string{allowedOrigins}
 	}
-	
+
 	c := cors.New(cors.Options{
 		AllowedOrigins:   origins,
 		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},

--- a/proxy/monitoring_test.go
+++ b/proxy/monitoring_test.go
@@ -1,0 +1,235 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+)
+
+func TestFetchMonitoringSummaryAggregatesStates(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/connectors":
+			json.NewEncoder(w).Encode([]string{"alpha", "beta"})
+		case "/connectors/alpha/status":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"name": "alpha",
+				"connector": map[string]interface{}{
+					"state":     "RUNNING",
+					"worker_id": "worker-a",
+				},
+				"tasks": []map[string]interface{}{
+					{
+						"id":    0,
+						"state": "RUNNING",
+					},
+					{
+						"id":    1,
+						"state": "FAILED",
+					},
+				},
+				"type": "source",
+			})
+		case "/connectors/beta/status":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"name": "beta",
+				"connector": map[string]interface{}{
+					"state":     "PAUSED",
+					"worker_id": "worker-b",
+				},
+				"tasks": []map[string]interface{}{
+					{
+						"id":    0,
+						"state": "UNASSIGNED",
+					},
+					{
+						"id":    1,
+						"state": "CUSTOM",
+					},
+				},
+				"type": "sink",
+			})
+		case "/":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"server_info": map[string]interface{}{
+					"uptime_ms": 9870,
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	summary, err := fetchMonitoringSummary(context.Background(), server.Client(), server.URL)
+	if err != nil {
+		t.Fatalf("fetchMonitoringSummary returned error: %v", err)
+	}
+
+	if summary.TotalConnectors != 2 {
+		t.Fatalf("expected 2 connectors, got %d", summary.TotalConnectors)
+	}
+
+	if got := summary.ConnectorStates["running"]; got != 1 {
+		t.Fatalf("expected 1 running connector, got %d", got)
+	}
+
+	if got := summary.ConnectorStates["paused"]; got != 1 {
+		t.Fatalf("expected 1 paused connector, got %d", got)
+	}
+
+	expectedTaskStates := map[string]int{
+		"running":    1,
+		"failed":     1,
+		"unassigned": 1,
+		"unknown":    1,
+	}
+
+	for state, expected := range expectedTaskStates {
+		if summary.TaskStates[state] != expected {
+			t.Fatalf("expected %d tasks in state %s, got %d", expected, state, summary.TaskStates[state])
+		}
+	}
+
+	if summary.UptimeSeconds != 9 {
+		t.Fatalf("expected uptime 9 seconds, got %d", summary.UptimeSeconds)
+	}
+
+	if len(summary.Connectors) != 2 {
+		t.Fatalf("expected 2 connector overviews, got %d", len(summary.Connectors))
+	}
+
+	overviewStates := map[string]string{}
+	for _, overview := range summary.Connectors {
+		overviewStates[overview.Name] = overview.State
+	}
+
+	if overviewStates["alpha"] != "running" {
+		t.Fatalf("expected alpha state running, got %s", overviewStates["alpha"])
+	}
+
+	if overviewStates["beta"] != "paused" {
+		t.Fatalf("expected beta state paused, got %s", overviewStates["beta"])
+	}
+}
+
+func TestMonitoringSummaryHandlerUnavailableConnect(t *testing.T) {
+	resetMonitoringSummaryCache()
+	originalURL := connectURL
+	connectURL = "http://127.0.0.1:1"
+	t.Cleanup(func() {
+		connectURL = originalURL
+	})
+
+	originalClient := monitoringHTTPClient
+	monitoringHTTPClient = &http.Client{Timeout: 50 * time.Millisecond}
+	t.Cleanup(func() {
+		monitoringHTTPClient = originalClient
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/default/monitoring/summary", nil)
+	req = mux.SetURLVars(req, map[string]string{"cluster": "default"})
+	rr := httptest.NewRecorder()
+
+	monitoringSummaryHandler(rr, req)
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected status 503, got %d", rr.Code)
+	}
+
+	var payload map[string]string
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if payload["error"] != "connect_unreachable" {
+		t.Fatalf("expected error connect_unreachable, got %s", payload["error"])
+	}
+
+	if payload["message"] == "" {
+		t.Fatalf("expected error message to be populated")
+	}
+}
+
+func TestMonitoringSummaryHandlerUsesCache(t *testing.T) {
+	resetMonitoringSummaryCache()
+
+	var mu sync.Mutex
+	connectorCalls := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/connectors":
+			mu.Lock()
+			connectorCalls++
+			mu.Unlock()
+			json.NewEncoder(w).Encode([]string{"alpha"})
+		case "/connectors/alpha/status":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"name": "alpha",
+				"connector": map[string]interface{}{
+					"state":     "RUNNING",
+					"worker_id": "worker-a",
+				},
+				"tasks": []map[string]interface{}{},
+				"type":  "source",
+			})
+		case "/":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"uptime": 42,
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	originalURL := connectURL
+	connectURL = server.URL
+	t.Cleanup(func() {
+		connectURL = originalURL
+	})
+
+	originalClient := monitoringHTTPClient
+	monitoringHTTPClient = server.Client()
+	t.Cleanup(func() {
+		monitoringHTTPClient = originalClient
+	})
+
+	originalTTL := summaryCacheTTL
+	summaryCacheTTL = time.Minute
+	t.Cleanup(func() {
+		summaryCacheTTL = originalTTL
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/default/monitoring/summary", nil)
+	req = mux.SetURLVars(req, map[string]string{"cluster": "default"})
+
+	rr := httptest.NewRecorder()
+	monitoringSummaryHandler(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rr.Code)
+	}
+
+	rr2 := httptest.NewRecorder()
+	monitoringSummaryHandler(rr2, req)
+	if rr2.Code != http.StatusOK {
+		t.Fatalf("expected status 200 on cached response, got %d", rr2.Code)
+	}
+
+	mu.Lock()
+	calls := connectorCalls
+	mu.Unlock()
+
+	if calls != 1 {
+		t.Fatalf("expected connectors endpoint to be called once, got %d", calls)
+	}
+}


### PR DESCRIPTION
## Summary
- add monitoring summary aggregation helpers to collect connector state counts and uptime metadata
- expose GET /api/{cluster}/monitoring/summary using a 10s in-memory cache and improved Kafka Connect unavailability errors
- cover aggregation, uptime propagation, error handling, and cache reuse with new monitoring unit tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68ec78f982f48328b27face3052ac1e1