### PR TITLE
Add monitoring dashboard and shared navigation

### DIFF
--- a/web/app/components/Navigation.tsx
+++ b/web/app/components/Navigation.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useMonitoringSummary } from '../monitoring/MonitoringSummaryProvider';
+
+const navItems = [
+  { href: '/', label: 'Home' },
+  { href: '/monitoring', label: 'Monitoring' },
+];
+
+export function Navigation() {
+  const pathname = usePathname();
+  const { hasFailures } = useMonitoringSummary();
+
+  return (
+    <nav className="bg-white border-b border-gray-200 shadow-sm" aria-label="Main navigation">
+      <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-4 sm:px-6 lg:px-8">
+        <p className="text-lg font-semibold text-gray-900">Kafka Connect Console</p>
+        <div className="flex items-center gap-6">
+          {navItems.map(({ href, label }) => {
+            const isActive = pathname === href || (href !== '/' && pathname.startsWith(href));
+            const baseClasses =
+              'relative text-sm font-medium transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500';
+            const activeClasses = isActive ? 'text-blue-600' : 'text-gray-600 hover:text-gray-900';
+            const showFailureDot = label === 'Monitoring' && hasFailures;
+
+            return (
+              <Link key={href} href={href} className={`${baseClasses} ${activeClasses}`}>
+                <span>{label}</span>
+                {showFailureDot && (
+                  <span className="absolute -right-3 -top-1 inline-flex h-2 w-2 rounded-full bg-red-500" aria-hidden="true" />
+                )}
+                {showFailureDot && (
+                  <span className="sr-only">Monitoring has failing connectors</span>
+                )}
+              </Link>
+            );
+          })}
+        </div>
+      </div>
+    </nav>
+  );
+}

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import { MonitoringSummaryProvider } from "./monitoring/MonitoringSummaryProvider";
+import { Navigation } from "./components/Navigation";
 
 export const metadata: Metadata = {
   title: "Kafka Connect Console",
@@ -13,8 +15,13 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className="antialiased">
-        {children}
+      <body className="bg-gray-50 text-gray-900 antialiased">
+        <MonitoringSummaryProvider>
+          <div className="flex min-h-screen flex-col">
+            <Navigation />
+            <main className="flex-1">{children}</main>
+          </div>
+        </MonitoringSummaryProvider>
       </body>
     </html>
   );

--- a/web/app/monitoring/MonitoringSummaryProvider.tsx
+++ b/web/app/monitoring/MonitoringSummaryProvider.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import {
+  PropsWithChildren,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+interface MonitoringTotals {
+  total?: number;
+  running?: number;
+  degraded?: number;
+  failed?: number;
+  [key: string]: unknown;
+}
+
+export interface ConnectorSummary {
+  name: string;
+  state?: string;
+  status?: string;
+  tasks?: number | { state?: string }[];
+  tasksCount?: number;
+  lastError?: string | null;
+  trace?: string | null;
+  [key: string]: unknown;
+}
+
+export interface MonitoringSummary {
+  clusterId?: string;
+  uptime?: string;
+  totals?: MonitoringTotals;
+  connectors?: ConnectorSummary[];
+  [key: string]: unknown;
+}
+
+interface MonitoringSummaryContextValue {
+  apiBaseUrl: string;
+  clusterId: string;
+  summary: MonitoringSummary | null;
+  loading: boolean;
+  error: string | null;
+  isRefreshing: boolean;
+  hasFailures: boolean;
+  refresh: () => Promise<void>;
+}
+
+const MonitoringSummaryContext = createContext<MonitoringSummaryContextValue | undefined>(
+  undefined,
+);
+
+const DEFAULT_PROXY_URL = process.env.NEXT_PUBLIC_PROXY_URL ?? 'http://localhost:8080';
+const DEFAULT_CLUSTER_ID = process.env.NEXT_PUBLIC_CLUSTER_ID ?? 'default';
+
+export function MonitoringSummaryProvider({ children }: PropsWithChildren) {
+  const [summary, setSummary] = useState<MonitoringSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const hasMountedRef = useRef(true);
+  const isInitialFetch = useRef(true);
+
+  const apiBaseUrl = DEFAULT_PROXY_URL;
+  const clusterId = DEFAULT_CLUSTER_ID;
+  const summaryUrl = `${apiBaseUrl}/api/${clusterId}/monitoring/summary`;
+
+  const fetchSummary = useCallback(async () => {
+    try {
+      setError(null);
+      if (!isInitialFetch.current) {
+        setIsRefreshing(true);
+      }
+      const response = await fetch(summaryUrl, { cache: 'no-store' });
+      if (!response.ok) {
+        throw new Error('Failed to fetch monitoring summary');
+      }
+      const payload = (await response.json()) as MonitoringSummary;
+      if (hasMountedRef.current) {
+        setSummary(payload);
+        setLoading(false);
+      }
+    } catch (err) {
+      if (hasMountedRef.current) {
+        setError(err instanceof Error ? err.message : 'An unexpected error occurred');
+        setLoading(false);
+      }
+    } finally {
+      if (hasMountedRef.current) {
+        if (isInitialFetch.current) {
+          isInitialFetch.current = false;
+        }
+        if (!isInitialFetch.current) {
+          setTimeout(() => {
+            if (hasMountedRef.current) {
+              setIsRefreshing(false);
+            }
+          }, 400);
+        } else {
+          setIsRefreshing(false);
+        }
+      }
+    }
+  }, [summaryUrl]);
+
+  useEffect(() => {
+    hasMountedRef.current = true;
+    fetchSummary();
+    const interval = setInterval(fetchSummary, 10000);
+    return () => {
+      hasMountedRef.current = false;
+      clearInterval(interval);
+    };
+  }, [fetchSummary]);
+
+  const hasFailures = Boolean(summary?.totals && (summary.totals.failed ?? 0) > 0);
+
+  const value = useMemo<MonitoringSummaryContextValue>(
+    () => ({
+      apiBaseUrl,
+      clusterId,
+      summary,
+      loading,
+      error,
+      isRefreshing,
+      hasFailures,
+      refresh: fetchSummary,
+    }),
+    [apiBaseUrl, clusterId, error, fetchSummary, hasFailures, isRefreshing, loading, summary],
+  );
+
+  return (
+    <MonitoringSummaryContext.Provider value={value}>
+      {children}
+    </MonitoringSummaryContext.Provider>
+  );
+}
+
+export function useMonitoringSummary() {
+  const context = useContext(MonitoringSummaryContext);
+  if (!context) {
+    throw new Error('useMonitoringSummary must be used within a MonitoringSummaryProvider');
+  }
+  return context;
+}

--- a/web/app/monitoring/page.tsx
+++ b/web/app/monitoring/page.tsx
@@ -1,0 +1,218 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { ConnectorSummary, useMonitoringSummary } from './MonitoringSummaryProvider';
+
+function getConnectorState(connector: ConnectorSummary) {
+  const rawState = (connector.state ?? connector.status ?? 'UNKNOWN').toString();
+  return rawState.toUpperCase();
+}
+
+function getStateStyles(state: string) {
+  switch (state) {
+    case 'RUNNING':
+      return 'bg-green-100 text-green-700';
+    case 'DEGRADED':
+    case 'PAUSED':
+      return 'bg-yellow-100 text-yellow-700';
+    case 'FAILED':
+    case 'ERROR':
+      return 'bg-red-100 text-red-700';
+    default:
+      return 'bg-gray-100 text-gray-700';
+  }
+}
+
+function getTasksCount(connector: ConnectorSummary) {
+  if (typeof connector.tasks === 'number') {
+    return connector.tasks;
+  }
+  if (Array.isArray(connector.tasks)) {
+    return connector.tasks.length;
+  }
+  if (typeof connector.tasksCount === 'number') {
+    return connector.tasksCount;
+  }
+  return 0;
+}
+
+function getLastError(connector: ConnectorSummary) {
+  if (typeof connector.lastError === 'string' && connector.lastError.trim().length > 0) {
+    return connector.lastError;
+  }
+  if (typeof connector.trace === 'string' && connector.trace.trim().length > 0) {
+    return connector.trace;
+  }
+  return '—';
+}
+
+export default function MonitoringPage() {
+  const { summary, loading, error, clusterId } = useMonitoringSummary();
+  const [animateRefresh, setAnimateRefresh] = useState(false);
+  const previousSummary = useRef(summary);
+
+  useEffect(() => {
+    if (!summary) {
+      previousSummary.current = summary;
+      return;
+    }
+
+    if (previousSummary.current && summary !== previousSummary.current) {
+      setAnimateRefresh(true);
+      const timeout = setTimeout(() => setAnimateRefresh(false), 400);
+      previousSummary.current = summary;
+      return () => clearTimeout(timeout);
+    }
+
+    previousSummary.current = summary;
+  }, [summary]);
+
+  const totals = summary?.totals ?? {};
+  const uptime = summary?.uptime ?? 'Unknown uptime';
+  const connectors = summary?.connectors ?? [];
+  const totalConnectors = totals.total ?? connectors.length;
+  const running = totals.running ?? 0;
+  const degraded = totals.degraded ?? 0;
+  const failed = totals.failed ?? 0;
+
+  const fadeClass = animateRefresh ? 'opacity-95' : 'opacity-100';
+
+  const connectorsView = useMemo(() => {
+    if (!connectors.length) {
+      return (
+        <div className="rounded-lg border border-gray-200 bg-white p-6 text-center text-sm text-gray-600">
+          No connectors reported by the monitoring endpoint.
+        </div>
+      );
+    }
+
+    return (
+      <div className={`overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm transition-opacity duration-500 ${fadeClass}`}>
+        <table className="min-w-full divide-y divide-gray-200" role="table">
+          <thead className="bg-gray-50">
+            <tr>
+              <th scope="col" className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                Connector
+              </th>
+              <th scope="col" className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                State
+              </th>
+              <th scope="col" className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                Tasks
+              </th>
+              <th scope="col" className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                Last error
+              </th>
+              <th scope="col" className="px-6 py-3 text-right text-xs font-semibold uppercase tracking-wide text-gray-500">
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200">
+            {connectors.map((connector) => {
+              const state = getConnectorState(connector);
+              const badgeStyles = getStateStyles(state);
+              const tasks = getTasksCount(connector);
+              const lastError = getLastError(connector);
+
+              return (
+                <tr key={connector.name} className="hover:bg-gray-50 focus-within:bg-gray-50">
+                  <td className="whitespace-nowrap px-6 py-4 text-sm font-medium text-gray-900">
+                    {connector.name}
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4">
+                    <span className={`inline-flex rounded-full px-3 py-1 text-xs font-semibold ${badgeStyles}`}>
+                      {state}
+                    </span>
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-700">{tasks}</td>
+                  <td className="px-6 py-4 text-sm text-gray-700">
+                    <span
+                      className="block max-h-12 overflow-hidden break-words"
+                      title={lastError}
+                    >
+                      {lastError}
+                    </span>
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 text-right text-sm font-medium">
+                    <Link
+                      className="text-blue-600 hover:text-blue-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+                      href={`/connectors/${encodeURIComponent(connector.name)}`}
+                    >
+                      View
+                    </Link>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    );
+  }, [connectors, fadeClass]);
+
+  if (loading) {
+    return (
+      <section className="mx-auto flex max-w-7xl flex-1 items-center justify-center px-4 py-24 sm:px-6 lg:px-8">
+        <div className="text-center">
+          <div className="mx-auto mb-4 h-10 w-10 animate-spin rounded-full border-4 border-blue-200 border-t-blue-600" aria-hidden />
+          <p className="text-sm font-medium text-gray-600">Loading monitoring data…</p>
+        </div>
+      </section>
+    );
+  }
+
+  if (error) {
+    return (
+      <section className="mx-auto max-w-3xl px-4 py-10 sm:px-6 lg:px-8">
+        <div className="rounded-lg border border-red-200 bg-red-50 p-6">
+          <h2 className="text-lg font-semibold text-red-700">Unable to load monitoring data</h2>
+          <p className="mt-2 text-sm text-red-600">{error}</p>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="mx-auto w-full max-w-7xl px-4 py-10 sm:px-6 lg:px-8">
+      <header className="mb-10">
+        <p className="text-sm font-medium text-gray-500">Cluster: {summary?.clusterId ?? clusterId}</p>
+        <h1 className="mt-1 text-3xl font-bold text-gray-900">Monitoring Overview</h1>
+        <p className="mt-2 text-sm text-gray-600">Uptime: {uptime}</p>
+      </header>
+
+      <div className="mb-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <div className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
+          <p className="text-sm font-medium text-gray-500">Total connectors</p>
+          <p className="mt-2 text-2xl font-semibold text-gray-900">{totalConnectors}</p>
+        </div>
+        <div className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
+          <p className="text-sm font-medium text-gray-500">🟢 Running</p>
+          <p className="mt-2 text-2xl font-semibold text-green-700">{running}</p>
+        </div>
+        <div className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
+          <p className="text-sm font-medium text-gray-500">🟡 Degraded</p>
+          <p className="mt-2 text-2xl font-semibold text-yellow-700">{degraded}</p>
+        </div>
+        <div className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
+          <p className="text-sm font-medium text-gray-500">🔴 Failed</p>
+          <p className="mt-2 text-2xl font-semibold text-red-700">{failed}</p>
+        </div>
+      </div>
+
+      {failed > 0 && (
+        <div className="mb-8 rounded-lg border border-red-200 bg-red-50 p-5">
+          <h2 className="text-lg font-semibold text-red-700">Attention required</h2>
+          <p className="mt-2 text-sm text-red-600">
+            {failed === 1
+              ? '1 connector is reporting a failure. Investigate the error details below.'
+              : `${failed} connectors are reporting failures. Investigate the error details below.`}
+          </p>
+        </div>
+      )}
+
+      {connectorsView}
+    </section>
+  );
+}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,116 +1,99 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import Link from 'next/link';
+import { useCallback, useEffect, useState } from 'react';
 
 interface Connector {
   name: string;
-  type: string;
 }
+
+const PROXY_URL = process.env.NEXT_PUBLIC_PROXY_URL ?? 'http://localhost:8080';
+const CLUSTER_ID = process.env.NEXT_PUBLIC_CLUSTER_ID ?? 'default';
 
 export default function Home() {
   const [connectors, setConnectors] = useState<Connector[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const cluster = 'default';
+  const connectorsEndpoint = `${PROXY_URL}/api/${CLUSTER_ID}/connectors`;
 
-  useEffect(() => {
-    fetchConnectors();
-  }, []);
-
-  const fetchConnectors = async () => {
+  const fetchConnectors = useCallback(async () => {
     try {
       setLoading(true);
       setError(null);
-      const response = await fetch(`http://localhost:8080/api/${cluster}/connectors`);
+      const response = await fetch(connectorsEndpoint, { cache: 'no-store' });
       if (!response.ok) {
         throw new Error('Failed to fetch connectors');
       }
       const data = await response.json();
-      
-      // Kafka Connect returns an array of connector names
-      const connectorList = Array.isArray(data) ? data.map((name: string) => ({
-        name,
-        type: 'Unknown' // We'll fetch details later
-      })) : [];
-      
+      const connectorList = Array.isArray(data)
+        ? data.map((name: string) => ({ name }))
+        : [];
       setConnectors(connectorList);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An error occurred');
     } finally {
       setLoading(false);
     }
-  };
+  }, [connectorsEndpoint]);
+
+  useEffect(() => {
+    fetchConnectors();
+  }, [fetchConnectors]);
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      <header className="bg-white shadow">
-        <div className="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
-          <h1 className="text-3xl font-bold text-gray-900">Kafka Connect Console</h1>
+    <section className="mx-auto w-full max-w-7xl px-4 py-10 sm:px-6 lg:px-8">
+      <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-3xl font-bold text-gray-900">Connectors</h1>
+          <p className="text-sm text-gray-600">Cluster: {CLUSTER_ID}</p>
         </div>
-      </header>
+        <button
+          onClick={fetchConnectors}
+          className="inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+        >
+          Refresh
+        </button>
+      </div>
 
-      <main className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
-        <div className="px-4 py-6 sm:px-0">
-          <div className="flex justify-between items-center mb-6">
-            <h2 className="text-2xl font-semibold text-gray-900">Connectors</h2>
-            <button
-              onClick={fetchConnectors}
-              className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
-            >
-              Refresh
-            </button>
-          </div>
-
-          {loading && (
-            <div className="text-center py-8">
-              <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900"></div>
-              <p className="mt-2 text-gray-600">Loading connectors...</p>
-            </div>
-          )}
-
-          {error && (
-            <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded mb-4">
-              <p className="font-bold">Error</p>
-              <p>{error}</p>
-            </div>
-          )}
-
-          {!loading && !error && connectors.length === 0 && (
-            <div className="bg-yellow-50 border border-yellow-200 text-yellow-700 px-4 py-3 rounded">
-              <p>No connectors found. Start by creating a new connector.</p>
-            </div>
-          )}
-
-          {!loading && !error && connectors.length > 0 && (
-            <div className="bg-white shadow overflow-hidden sm:rounded-md">
-              <ul className="divide-y divide-gray-200">
-                {connectors.map((connector) => (
-                  <li key={connector.name}>
-                    <Link
-                      href={`/connectors/${connector.name}`}
-                      className="block hover:bg-gray-50 transition duration-150 ease-in-out"
-                    >
-                      <div className="px-4 py-4 sm:px-6">
-                        <div className="flex items-center justify-between">
-                          <p className="text-lg font-medium text-blue-600 truncate">
-                            {connector.name}
-                          </p>
-                          <div className="ml-2 flex-shrink-0 flex">
-                            <p className="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">
-                              Active
-                            </p>
-                          </div>
-                        </div>
-                      </div>
-                    </Link>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
+      {loading && (
+        <div className="rounded-lg border border-gray-200 bg-white p-8 text-center">
+          <div
+            className="mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-4 border-blue-200 border-t-blue-600"
+            aria-hidden
+          />
+          <p className="text-sm text-gray-600">Loading connectors…</p>
         </div>
-      </main>
-    </div>
+      )}
+
+      {error && (
+        <div className="mb-6 rounded-lg border border-red-200 bg-red-50 p-6">
+          <h2 className="text-lg font-semibold text-red-700">Error</h2>
+          <p className="mt-2 text-sm text-red-600">{error}</p>
+        </div>
+      )}
+
+      {!loading && !error && connectors.length === 0 && (
+        <div className="rounded-lg border border-yellow-200 bg-yellow-50 p-6 text-sm text-yellow-800">
+          No connectors found. Start by creating a new connector.
+        </div>
+      )}
+
+      {!loading && !error && connectors.length > 0 && (
+        <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+          <ul className="divide-y divide-gray-200">
+            {connectors.map((connector) => (
+              <li key={connector.name}>
+                <Link
+                  href={`/connectors/${encodeURIComponent(connector.name)}`}
+                  className="block px-4 py-4 transition hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 sm:px-6"
+                >
+                  <p className="text-lg font-medium text-blue-600">{connector.name}</p>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </section>
   );
 }


### PR DESCRIPTION
## Summary
- add a monitoring summary provider that polls the Kafka Connect proxy every 10 seconds and exposes failure state to consumers
- build a monitoring overview page with KPI cards, failure alerts, a status table, and a subtle refresh animation
- update the root layout with shared navigation plus refreshed connectors list styling tied to configurable cluster settings

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ec78fce6a48328a0bff612855118c4