### PR TITLE
Add test utility helpers for proxy integration tests

### DIFF
--- a/proxy/testdata/connector-status.json
+++ b/proxy/testdata/connector-status.json
@@ -1,0 +1,21 @@
+{
+  "name": "inventory-source",
+  "connector": {
+    "state": "RUNNING",
+    "worker_id": "connect-worker-0:8083"
+  },
+  "tasks": [
+    {
+      "id": 0,
+      "state": "RUNNING",
+      "worker_id": "connect-worker-0:8083"
+    },
+    {
+      "id": 1,
+      "state": "FAILED",
+      "worker_id": "connect-worker-1:8083",
+      "trace": "org.apache.kafka.connect.errors.ConnectException: Task failed to start"
+    }
+  ],
+  "type": "source"
+}

--- a/proxy/testutils/fixtures.go
+++ b/proxy/testutils/fixtures.go
@@ -1,0 +1,55 @@
+package testutils
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// LoadFixture reads a file from the proxy/testdata directory and returns its raw bytes.
+func LoadFixture(t testing.TB, filename string) []byte {
+	t.Helper()
+
+	path := filepath.Join(testdataDir(t), filename)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read fixture %q: %v", filename, err)
+	}
+
+	return data
+}
+
+// LoadJSONFixture reads a JSON fixture from proxy/testdata and unmarshals it into the
+// provided value.
+func LoadJSONFixture(t testing.TB, filename string, v interface{}) {
+	t.Helper()
+
+	data := LoadFixture(t, filename)
+	if err := json.Unmarshal(data, v); err != nil {
+		t.Fatalf("failed to unmarshal fixture %q: %v", filename, err)
+	}
+}
+
+// NewTestClient returns an HTTP client configured for interacting with the provided
+// httptest.Server. A short timeout is applied to keep tests responsive.
+func NewTestClient(server *httptest.Server) *http.Client {
+	client := server.Client()
+	client.Timeout = 5 * time.Second
+	return client
+}
+
+func testdataDir(t testing.TB) string {
+	t.Helper()
+
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatalf("unable to resolve caller information for fixture loading")
+	}
+
+	return filepath.Join(filepath.Dir(currentFile), "..", "testdata")
+}

--- a/proxy/testutils/server.go
+++ b/proxy/testutils/server.go
@@ -1,0 +1,85 @@
+package testutils
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// MockResponse defines the payload returned by a mock Kafka Connect server.
+type MockResponse struct {
+	// Status is the HTTP status code returned to the client. Defaults to 200.
+	Status int
+	// Body is the raw response payload returned to the client.
+	Body []byte
+	// Headers contains HTTP headers that should be set on the response.
+	Headers map[string]string
+	// Methods restricts the HTTP methods that this response will accept.
+	// If empty, all methods are allowed.
+	Methods []string
+}
+
+// NewConnectServer spins up an httptest.Server with deterministic responses for the
+// provided route map. Each key should be an absolute path (e.g. "/connectors/foo/status").
+//
+// If a request does not match any provided route a 404 will be returned. When Methods
+// is provided, any request using a different verb receives a 405 response.
+func NewConnectServer(t testing.TB, routes map[string]MockResponse) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	for path, resp := range routes {
+		path := path
+		response := resp
+		allowedMethods := make(map[string]struct{}, len(response.Methods))
+		for _, method := range response.Methods {
+			allowedMethods[strings.ToUpper(method)] = struct{}{}
+		}
+
+		mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+			if len(allowedMethods) > 0 {
+				if _, ok := allowedMethods[r.Method]; !ok {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+			}
+
+			for key, value := range response.Headers {
+				w.Header().Set(key, value)
+			}
+
+			status := response.Status
+			if status == 0 {
+				status = http.StatusOK
+			}
+			w.WriteHeader(status)
+			if len(response.Body) > 0 {
+				_, _ = w.Write(response.Body)
+			}
+		})
+	}
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	})
+
+	return httptest.NewServer(mux)
+}
+
+// NewJSONConnectServer is a convenience wrapper around NewConnectServer that sets the
+// Content-Type header to application/json for all responses.
+func NewJSONConnectServer(t testing.TB, routes map[string]MockResponse) *httptest.Server {
+	t.Helper()
+
+	for path, resp := range routes {
+		if resp.Headers == nil {
+			resp.Headers = map[string]string{"Content-Type": "application/json"}
+		} else if _, ok := resp.Headers["Content-Type"]; !ok {
+			resp.Headers["Content-Type"] = "application/json"
+		}
+		routes[path] = resp
+	}
+
+	return NewConnectServer(t, routes)
+}


### PR DESCRIPTION
## Summary
- add reusable httptest server helpers for deterministic Kafka Connect responses
- expose fixture loaders and shared HTTP client helpers for proxy tests
- contribute representative connector status JSON fixture for forwarding scenarios

## Testing
- go test ./... -run TestRedactSensitiveData -count=1 -v

------
https://chatgpt.com/codex/tasks/task_e_68ed09ee4c708328b922cc3b801b2c21