### PR TITLE
Add proxy handler tests with Kafka Connect test server

### DIFF
--- a/proxy/main_test.go
+++ b/proxy/main_test.go
@@ -2,7 +2,13 @@ package main
 
 import (
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+
+	"github.com/gorilla/mux"
+
+	"github.com/mcnabb998/kconnect-console/proxy/testutils"
 )
 
 func TestRedactSensitiveData(t *testing.T) {
@@ -80,14 +86,148 @@ func TestRedactSensitiveData(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := redactSensitiveData(tt.input)
-			
+
 			// Convert to JSON for easy comparison
 			resultJSON, _ := json.Marshal(result)
 			expectedJSON, _ := json.Marshal(tt.expected)
-			
+
 			if string(resultJSON) != string(expectedJSON) {
 				t.Errorf("redactSensitiveData() = %v, want %v", string(resultJSON), string(expectedJSON))
 			}
 		})
+	}
+}
+
+func TestHealthHandler(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rr := httptest.NewRecorder()
+
+	healthHandler(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rr.Code)
+	}
+
+	if contentType := rr.Header().Get("Content-Type"); contentType != "application/json" {
+		t.Fatalf("expected application/json content type, got %s", contentType)
+	}
+
+	var payload map[string]string
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if payload["status"] != "healthy" {
+		t.Fatalf("expected health status healthy, got %s", payload["status"])
+	}
+}
+
+func TestProxyHandler_ForwardsRequestsAndRedacts(t *testing.T) {
+	responses := map[string]testutils.Response{
+		"GET /connectors": {
+			Status:  http.StatusOK,
+			Body:    []string{"alpha"},
+			Headers: map[string]string{"Content-Type": "application/json"},
+		},
+		"GET /connectors/datagen-users": {
+			Status: http.StatusOK,
+			Body: map[string]interface{}{
+				"name": "datagen-users",
+				"config": map[string]interface{}{
+					"database.password": "supersecret",
+					"key.converter":     "org.apache.kafka.connect.storage.StringConverter",
+				},
+			},
+			Headers: map[string]string{"Content-Type": "application/json"},
+		},
+		"GET /connectors/datagen-users/status": {
+			Status:  http.StatusOK,
+			Body:    map[string]string{"state": "RUNNING"},
+			Headers: map[string]string{"Content-Type": "application/json"},
+		},
+	}
+
+	connectServer := testutils.NewConnectServer(responses)
+	defer connectServer.Close()
+
+	originalURL := connectURL
+	connectURL = connectServer.URL()
+	t.Cleanup(func() {
+		connectURL = originalURL
+	})
+
+	listReq := httptest.NewRequest(http.MethodGet, "/api/default/connectors", nil)
+	listReq = mux.SetURLVars(listReq, map[string]string{"cluster": "default"})
+	listRecorder := httptest.NewRecorder()
+	proxyHandler(listRecorder, listReq)
+
+	if listRecorder.Code != http.StatusOK {
+		t.Fatalf("expected status 200 for connectors list, got %d", listRecorder.Code)
+	}
+
+	var connectors []string
+	if err := json.Unmarshal(listRecorder.Body.Bytes(), &connectors); err != nil {
+		t.Fatalf("failed to decode connectors response: %v", err)
+	}
+
+	if len(connectors) != 1 || connectors[0] != "alpha" {
+		t.Fatalf("unexpected connectors payload: %v", connectors)
+	}
+
+	detailReq := httptest.NewRequest(http.MethodGet, "/api/default/connectors/datagen-users", nil)
+	detailReq = mux.SetURLVars(detailReq, map[string]string{"cluster": "default", "path": "datagen-users"})
+	detailRecorder := httptest.NewRecorder()
+	proxyHandler(detailRecorder, detailReq)
+
+	if detailRecorder.Code != http.StatusOK {
+		t.Fatalf("expected status 200 for connector detail, got %d", detailRecorder.Code)
+	}
+
+	var detailPayload map[string]interface{}
+	if err := json.Unmarshal(detailRecorder.Body.Bytes(), &detailPayload); err != nil {
+		t.Fatalf("failed to decode connector detail: %v", err)
+	}
+
+	config, ok := detailPayload["config"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected config field in connector detail")
+	}
+
+	if got := config["database.password"]; got != "***REDACTED***" {
+		t.Fatalf("expected database.password to be redacted, got %v", got)
+	}
+
+	if got := config["key.converter"]; got != "org.apache.kafka.connect.storage.StringConverter" {
+		t.Fatalf("expected key.converter to remain unchanged, got %v", got)
+	}
+
+	statusReq := httptest.NewRequest(http.MethodGet, "/api/default/connectors/datagen-users/status", nil)
+	statusReq = mux.SetURLVars(statusReq, map[string]string{"cluster": "default", "path": "datagen-users/status"})
+	statusRecorder := httptest.NewRecorder()
+	proxyHandler(statusRecorder, statusReq)
+
+	if statusRecorder.Code != http.StatusOK {
+		t.Fatalf("expected status 200 for connector status, got %d", statusRecorder.Code)
+	}
+
+	var statusPayload map[string]string
+	if err := json.Unmarshal(statusRecorder.Body.Bytes(), &statusPayload); err != nil {
+		t.Fatalf("failed to decode connector status: %v", err)
+	}
+
+	if statusPayload["state"] != "RUNNING" {
+		t.Fatalf("expected connector state RUNNING, got %s", statusPayload["state"])
+	}
+
+	requests := connectServer.Requests()
+	if len(requests) != 3 {
+		t.Fatalf("expected 3 proxied requests, got %d", len(requests))
+	}
+
+	expectedPaths := []string{"/connectors", "/connectors/datagen-users", "/connectors/datagen-users/status"}
+	for i, expectedPath := range expectedPaths {
+		if requests[i].Path != expectedPath {
+			t.Fatalf("request %d path = %s, want %s", i, requests[i].Path, expectedPath)
+		}
 	}
 }

--- a/proxy/testutils/test_server.go
+++ b/proxy/testutils/test_server.go
@@ -1,0 +1,104 @@
+package testutils
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+)
+
+// Response represents a mocked Kafka Connect response specification.
+type Response struct {
+	Status  int
+	Body    interface{}
+	Headers map[string]string
+}
+
+// Request captures details about a request received by the mocked Kafka Connect server.
+type Request struct {
+	Method string
+	Path   string
+	Header http.Header
+	Body   []byte
+}
+
+// ConnectServer simulates a Kafka Connect endpoint for proxy tests.
+type ConnectServer struct {
+	server    *httptest.Server
+	mu        sync.Mutex
+	requests  []Request
+	responses map[string]Response
+}
+
+// NewConnectServer spins up an HTTP server that returns predefined responses per method + path.
+func NewConnectServer(responses map[string]Response) *ConnectServer {
+	cs := &ConnectServer{
+		responses: responses,
+	}
+
+	cs.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		r.Body.Close()
+
+		cs.mu.Lock()
+		cs.requests = append(cs.requests, Request{
+			Method: r.Method,
+			Path:   r.URL.Path,
+			Header: r.Header.Clone(),
+			Body:   body,
+		})
+		cs.mu.Unlock()
+
+		key := r.Method + " " + r.URL.Path
+		resp, ok := cs.responses[key]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		for header, value := range resp.Headers {
+			w.Header().Set(header, value)
+		}
+
+		status := resp.Status
+		if status == 0 {
+			status = http.StatusOK
+		}
+
+		w.WriteHeader(status)
+
+		switch body := resp.Body.(type) {
+		case nil:
+			return
+		case []byte:
+			w.Write(body)
+		default:
+			if err := json.NewEncoder(w).Encode(body); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+		}
+	}))
+
+	return cs
+}
+
+// URL returns the base URL of the mocked Kafka Connect server.
+func (cs *ConnectServer) URL() string {
+	return cs.server.URL
+}
+
+// Close shuts down the mocked Kafka Connect server.
+func (cs *ConnectServer) Close() {
+	cs.server.Close()
+}
+
+// Requests returns a snapshot of the requests received by the mocked server.
+func (cs *ConnectServer) Requests() []Request {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+
+	out := make([]Request, len(cs.requests))
+	copy(out, cs.requests)
+	return out
+}


### PR DESCRIPTION
## Summary
- add coverage for the health handler and proxy handler, including path rewriting and redaction assertions
- introduce a reusable testutils package that spins up a mock Kafka Connect server used by the proxy tests

## Testing
- go test ./... -cover

------
https://chatgpt.com/codex/tasks/task_e_68ed09ec8b008328939a14c9a69237b8