### PR TITLE
Create vertical navigation layout

### DIFF
--- a/web/app/components/Navigation.tsx
+++ b/web/app/components/Navigation.tsx
@@ -4,11 +4,18 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useMonitoringSummary } from '../monitoring/MonitoringSummaryProvider';
 
-const navItems = [
-  { href: '/', label: 'Home' },
-  { href: '/monitoring', label: 'Monitoring' },
-  { href: '/connectors/templates', label: 'Create Connector' },
-  { href: '/capabilities', label: 'Capabilities' },
+type NavItem = {
+  href: string;
+  label: string;
+  Icon: (props: { className?: string }) => JSX.Element;
+};
+
+const navItems: NavItem[] = [
+  { href: '/', label: 'Home', Icon: HomeIcon },
+  { href: '/monitoring', label: 'Monitoring', Icon: PulseIcon },
+  { href: '/connectors/templates', label: 'Create', Icon: PlusSquareIcon },
+  { href: '/capabilities', label: 'Capabilities', Icon: SparklesIcon },
+  { href: '/settings', label: 'Settings', Icon: SettingsIcon },
 ];
 
 export function Navigation() {
@@ -16,31 +23,149 @@ export function Navigation() {
   const { hasFailures } = useMonitoringSummary();
 
   return (
-    <nav className="bg-white border-b border-gray-200 shadow-sm" aria-label="Main navigation">
-      <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-4 sm:px-6 lg:px-8">
+    <nav className="flex h-full flex-col px-6 py-8" aria-label="Main navigation">
+      <div className="mb-8 flex flex-col gap-1">
         <p className="text-lg font-semibold text-gray-900">Kafka Connect Console</p>
-        <div className="flex items-center gap-6">
-          {navItems.map(({ href, label }) => {
-            const isActive = pathname === href || (href !== '/' && pathname.startsWith(href));
-            const baseClasses =
-              'relative text-sm font-medium transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500';
-            const activeClasses = isActive ? 'text-blue-600' : 'text-gray-600 hover:text-gray-900';
-            const showFailureDot = label === 'Monitoring' && hasFailures;
+        <p className="text-sm text-gray-500">Manage and monitor your data pipelines</p>
+      </div>
+      <ul className="flex flex-1 flex-col gap-2">
+        {navItems.map(({ href, label, Icon }) => {
+          const isActive = pathname === href || (href !== '/' && pathname.startsWith(href));
+          const showFailureBadge = label === 'Monitoring' && hasFailures;
 
-            return (
-              <Link key={href} href={href} className={`${baseClasses} ${activeClasses}`}>
-                <span>{label}</span>
-                {showFailureDot && (
-                  <span className="absolute -right-3 -top-1 inline-flex h-2 w-2 rounded-full bg-red-500" aria-hidden="true" />
+          return (
+            <li key={href}>
+              <Link
+                href={href}
+                aria-current={isActive ? 'page' : undefined}
+                className={`group flex items-center gap-3 rounded-2xl px-4 py-3 text-sm font-medium transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white ${
+                  isActive
+                    ? 'bg-blue-50 text-blue-600'
+                    : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
+                }`}
+              >
+                <Icon
+                  className={`h-5 w-5 ${
+                    isActive ? 'text-blue-600' : 'text-gray-400 group-hover:text-gray-500'
+                  }`}
+                />
+                <span className="flex-1">{label}</span>
+                {showFailureBadge && (
+                  <span className="inline-flex items-center rounded-full bg-red-100 px-2 py-0.5 text-xs font-semibold text-red-600">
+                    !
+                  </span>
                 )}
-                {showFailureDot && (
+                {showFailureBadge && (
                   <span className="sr-only">Monitoring has failing connectors</span>
                 )}
               </Link>
-            );
-          })}
-        </div>
-      </div>
+            </li>
+          );
+        })}
+      </ul>
     </nav>
+  );
+}
+
+function HomeIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <path
+        d="M4 10.5 12 4l8 6.5V20a1 1 0 0 1-1 1h-4a1 1 0 0 1-1-1v-4.5h-4V20a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1v-9.5Z"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function PulseIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <path
+        d="m4 13 3.5-1.5L10 17l3.5-10 3 6 3.5-1.5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function PlusSquareIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <rect
+        x="4"
+        y="4"
+        width="16"
+        height="16"
+        rx="2"
+        stroke="currentColor"
+        strokeWidth="1.5"
+      />
+      <path d="M12 8v8m-4-4h8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function SparklesIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <path
+        d="M12 3v3m0 12v3m9-9h-3M6 12H3m14.5-6.5L18 7l1.5 1.5L18 10l-1.5-1.5L15 10l1.5-1.5L15 7l1.5-1.5L18 7l1.5-1.5ZM5.5 15.5 7 17l1.5 1.5L7 20l-1.5-1.5L4 20l1.5-1.5L4 17l1.5-1.5L7 17l-1.5-1.5Z"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function SettingsIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <path
+        d="M12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6Zm7.5-3.75a1 1 0 0 0 .5-.87v-1.76a1 1 0 0 0-.5-.87l-1.66-.96a1 1 0 0 1-.5-.87l-.03-1.92a1 1 0 0 0-.74-.96l-1.9-.5a1 1 0 0 0-1.02.36l-1.16 1.39a1 1 0 0 1-.9.34l-1.77-.26a1 1 0 0 0-1.01.47l-.95 1.65a1 1 0 0 1-.82.5L6.5 9.6a1 1 0 0 0-.87 1l.07 1.99a1 1 0 0 0 .5.87l1.66.96a1 1 0 0 1 .5.87l.03 1.92a1 1 0 0 0 .74.96l1.9.5a1 1 0 0 0 1.02-.36l1.16-1.39a1 1 0 0 1 .9-.34l1.77.26a1 1 0 0 0 1.01-.47l.95-1.65a1 1 0 0 1 .82-.5l1.92-.23Z"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
   );
 }

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -19,9 +19,15 @@ export default function RootLayout({
       <body className="bg-gray-50 text-gray-900 antialiased">
         <ErrorBoundary>
           <MonitoringSummaryProvider>
-            <div className="flex min-h-screen flex-col">
-              <Navigation />
-              <main className="flex-1">{children}</main>
+            <div className="flex min-h-screen">
+              <aside className="w-72 shrink-0 border-r border-gray-200 bg-white">
+                <Navigation />
+              </aside>
+              <main className="flex flex-1 justify-center">
+                <div className="flex w-full max-w-[1200px] flex-col gap-6 px-8 py-8">
+                  {children}
+                </div>
+              </main>
             </div>
           </MonitoringSummaryProvider>
         </ErrorBoundary>


### PR DESCRIPTION
## Summary
- restructure the root layout to pair a fixed navigation aside with a centered main content column
- redesign the navigation component into a vertical list with icons, focus treatments, and monitoring failure badge
- apply new spacing tokens to align with the refreshed layout system

## Testing
- npm --prefix web run test

------
https://chatgpt.com/codex/tasks/task_e_68edade4e810832898821b49ce38ead6