### PR TITLE
Enhance monitoring summary payload

### DIFF
--- a/proxy/monitoring_test.go
+++ b/proxy/monitoring_test.go
@@ -102,6 +102,22 @@ func TestFetchMonitoringSummaryAggregatesStates(t *testing.T) {
 		t.Fatalf("expected uptime 9 seconds, got %d", summary.UptimeSeconds)
 	}
 
+	if summary.Uptime != "9s" {
+		t.Fatalf("expected uptime label 9s, got %q", summary.Uptime)
+	}
+
+	if summary.Totals["total"] != 2 {
+		t.Fatalf("expected totals total 2, got %d", summary.Totals["total"])
+	}
+
+	if summary.Totals["failed"] != 0 {
+		t.Fatalf("expected totals failed 0, got %d", summary.Totals["failed"])
+	}
+
+	if summary.Totals["degraded"] != 2 {
+		t.Fatalf("expected totals degraded 2, got %d", summary.Totals["degraded"])
+	}
+
 	if len(summary.Connectors) != 2 {
 		t.Fatalf("expected 2 connector overviews, got %d", len(summary.Connectors))
 	}

--- a/web/app/monitoring/MonitoringSummaryProvider.tsx
+++ b/web/app/monitoring/MonitoringSummaryProvider.tsx
@@ -12,11 +12,11 @@ import {
 } from 'react';
 
 interface MonitoringTotals {
-  total?: number;
-  running?: number;
-  degraded?: number;
-  failed?: number;
-  [key: string]: unknown;
+  total: number;
+  running: number;
+  degraded: number;
+  failed: number;
+  [key: string]: number;
 }
 
 export interface ConnectorSummary {
@@ -41,6 +41,7 @@ export interface MonitoringSummary {
 interface MonitoringSummaryContextValue {
   apiBaseUrl: string;
   clusterId: string;
+  uptime: string;
   summary: MonitoringSummary | null;
   loading: boolean;
   error: string | null;
@@ -71,7 +72,7 @@ export function MonitoringSummaryProvider({ children }: PropsWithChildren) {
   const pollingIntervalRef = useRef<NodeJS.Timeout | null>(null);
 
   const apiBaseUrl = DEFAULT_PROXY_URL;
-  const clusterId = DEFAULT_CLUSTER_ID;
+  const clusterId = summary?.clusterId?.trim() ? summary.clusterId : DEFAULT_CLUSTER_ID;
   const summaryUrl = `${apiBaseUrl}/api/${clusterId}/monitoring/summary`;
 
   const fetchSummary = useCallback(async () => {
@@ -158,12 +159,14 @@ export function MonitoringSummaryProvider({ children }: PropsWithChildren) {
     void fetchSummary();
   }, [fetchSummary]);
 
-  const hasFailures = Boolean(summary?.totals && (summary.totals.failed ?? 0) > 0);
+  const hasFailures = (summary?.totals?.failed ?? 0) > 0;
+  const uptime = summary?.uptime?.trim() ? summary.uptime : 'unknown';
 
   const value = useMemo<MonitoringSummaryContextValue>(
     () => ({
       apiBaseUrl,
       clusterId,
+      uptime,
       summary,
       loading,
       error,
@@ -186,6 +189,7 @@ export function MonitoringSummaryProvider({ children }: PropsWithChildren) {
       pausePolling,
       resumePolling,
       summary,
+      uptime,
     ],
   );
 

--- a/web/app/monitoring/page.tsx
+++ b/web/app/monitoring/page.tsx
@@ -99,6 +99,7 @@ export default function MonitoringPage() {
     loading,
     error,
     clusterId,
+    uptime: clusterUptime,
     isPolling,
     pausePolling,
     resumePolling,
@@ -125,13 +126,13 @@ export default function MonitoringPage() {
     previousSummary.current = summary;
   }, [summary]);
 
-  const totals = summary?.totals ?? {};
-  const uptime = summary?.uptime ?? 'Unknown uptime';
+  const totals = summary?.totals;
+  const uptime = clusterUptime;
   const connectors = summary?.connectors ?? [];
-  const totalConnectors = totals.total ?? connectors.length;
-  const running = totals.running ?? 0;
-  const degraded = totals.degraded ?? 0;
-  const failed = totals.failed ?? 0;
+  const totalConnectors = totals?.total ?? 0;
+  const running = totals?.running ?? 0;
+  const degraded = totals?.degraded ?? 0;
+  const failed = totals?.failed ?? 0;
 
   const fadeClass = animateRefresh ? 'opacity-95' : 'opacity-100';
 


### PR DESCRIPTION
## Summary
- enrich the proxy monitoring summary with cluster metadata, uptime text, and derived totals
- expose the new summary fields through the monitoring context and simplify the page consumption
- extend the monitoring summary test coverage for the new response fields

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68edb52b4d948328a252af5e6463f065