### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/mcnabb998/kconnect-console/security/code-scanning/4](https://github.com/mcnabb998/kconnect-console/security/code-scanning/4)

The best way to address this problem is to explicitly set a minimal permissions block for the affected jobs in your workflow. Since the `lint` job (as well as the others, unless they push code, create PRs, or use workflow-dispatch, etc.) does not need to write to anything, it is sufficient to restrict permissions to `contents: read`. This can be done by adding a top-level `permissions` field just after the workflow `name: Tests` line, ensuring that all jobs inherit these minimal permissions. If some jobs need broader permissions, they can override this by specifying their own `permissions` block. In this case, starting with a minimal global permissions block is both safest and simplest.

**Specifically:**  
- Add the following lines immediately after the `name: Tests` at the top of `.github/workflows/test.yml`:
  ```yaml
  permissions:
    contents: read
  ```
- No new imports or external changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
