### PR TITLE
feat: add loading states to transformations and cluster pages

### DIFF
--- a/web/app/cluster/page.tsx
+++ b/web/app/cluster/page.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
+import { LoadingButton } from '@/components/LoadingButton';
 import { SkeletonBadge, SkeletonCard, SkeletonLine, SkeletonTableRow } from '@/components/Skeleton';
 import { getProxyUrl, API_CONFIG } from '@/lib/config';
 
@@ -571,13 +572,15 @@ export default function ClusterPage() {
             >
               Restart all connectors (unavailable)
             </button>
-            <button
-              type="button"
+            <LoadingButton
+              variant="ghost"
               onClick={() => refresh()}
-              className="inline-flex items-center gap-2 rounded-full border border-gray-200 px-4 py-2 text-sm font-medium text-gray-600 transition hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+              loading={loading}
+              loadingText="Refreshing..."
+              className="rounded-full border border-gray-200"
             >
               Refresh
-            </button>
+            </LoadingButton>
           </div>
         </div>
       </header>

--- a/web/app/connectors/[name]/TransformationsTab.tsx
+++ b/web/app/connectors/[name]/TransformationsTab.tsx
@@ -10,6 +10,7 @@ import type {
   SMTItem,
   ValidateResponse,
 } from '@/types/connect';
+import { LoadingButton } from '@/components/LoadingButton';
 import TransformEditor from '@/components/smts/TransformEditor';
 import TransformList from '@/components/smts/TransformList';
 import PreviewPanel from '@/components/smts/PreviewPanel';
@@ -457,8 +458,8 @@ export default function TransformationsTab({
           Changes are applied to the connector configuration. Validation must succeed before saving.
         </p>
         <div className="flex items-center gap-3">
-          <button
-            className="rounded-full border border-border px-4 py-2 text-sm font-medium text-muted-foreground hover:bg-muted disabled:opacity-50"
+          <LoadingButton
+            variant="secondary"
             onClick={() => {
               if (!connector) return;
               const resetItems = parseFromConnectorConfig(connector.config);
@@ -467,19 +468,20 @@ export default function TransformationsTab({
               setSelectedAlias(resetItems[0]?.alias ?? null);
               setStatusMessage('Changes discarded.');
             }}
-            type="button"
             disabled={saving}
+            className="rounded-full"
           >
             Reset
-          </button>
-          <button
-            className="rounded-full bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow-sm hover:bg-primary/90 disabled:opacity-50"
-            type="button"
+          </LoadingButton>
+          <LoadingButton
+            variant="primary"
             onClick={handleSave}
-            disabled={saving}
+            loading={saving}
+            loadingText="Saving..."
+            className="rounded-full"
           >
             Save Changes
-          </button>
+          </LoadingButton>
         </div>
       </div>
 


### PR DESCRIPTION
Extended LoadingButton to remaining pages that needed loading feedback.

Changes:
- TransformationsTab: Save Changes and Reset buttons now show loading states
  - Save button shows "Saving..." with spinner during save operation
  - Reset button disabled during save (prevents conflicts)

- Cluster page: Refresh button shows loading state
  - Shows "Refreshing..." with spinner during refresh
  - Prevents duplicate refresh requests

Benefits:
- Users see immediate feedback on Save Changes button
- Consistent loading experience across all pages
- Completes loading states implementation from IMPROVEMENTS.md #3

All Tests:
- 129/129 tests passing
- No new test files needed (covered by existing tests)

Closes remaining items from loading states plan:
- Step 5: Update transformations Save/Reset buttons ✅
- Step 6: Update cluster page Refresh button ✅

Related to IMPROVEMENTS.md #3 (Loading States)

🤖 Generated with [Claude Code](https://claude.com/claude-code)